### PR TITLE
Re-draw the indicator on setData()

### DIFF
--- a/carouselview/src/main/java/com/synnapps/carouselview/CarouselView.java
+++ b/carouselview/src/main/java/com/synnapps/carouselview/CarouselView.java
@@ -230,6 +230,8 @@ public class CarouselView extends FrameLayout {
         CarouselPagerAdapter carouselPagerAdapter = new CarouselPagerAdapter(getContext());
         containerViewPager.setAdapter(carouselPagerAdapter);
         mIndicator.setViewPager(containerViewPager);
+        mIndicator.requestLayout();
+        mIndicator.invalidate();
         containerViewPager.setOffscreenPageLimit(getPageCount());
         playCarousel();
     }


### PR DESCRIPTION
When calling setData() on the CarouselView, the bullets drawn by the CirclePageIndicator weren't updating correctly  and should be redrawn.

For example: initializing the CarouselView with 3 images, adding a 4th image to the list then calling setCount(4) on the CarouselView will leave the indicator with 3 white bullets (while still allowing to scroll past the 3rd one, having the black bullet going to/from the 4th white bullet indicator off-screen).

The fix simply mark the layout as needing a re-draw when setData() is called.