### PR TITLE
Continue changing views when the view is reattached

### DIFF
--- a/carouselview/src/main/java/com/synnapps/carouselview/CarouselView.java
+++ b/carouselview/src/main/java/com/synnapps/carouselview/CarouselView.java
@@ -131,11 +131,17 @@ public class CarouselView extends FrameLayout {
             }
         }
     }
-    
+
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        swipeTimer.cancel();
+        resetScrollTimer();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        playCarousel();
     }
 
     public int getSlideInterval() {
@@ -246,7 +252,6 @@ public class CarouselView extends FrameLayout {
     }
 
     private void stopScrollTimer() {
-
         if (null != swipeTimer) {
             swipeTimer.cancel();
         }
@@ -258,13 +263,12 @@ public class CarouselView extends FrameLayout {
 
 
     private void resetScrollTimer() {
-
         stopScrollTimer();
 
         swipeTask = new SwipeTask();
         swipeTimer = new Timer();
-
     }
+
 
     /**
      * Starts auto scrolling if


### PR DESCRIPTION
*Background*
it's a fix for the bug with reattached view.
steps:
1. add CarouselView to ViewHolder of RecycerView
2. scroll the view out of the screen
3. scroll back and see that autoPlay is stopped

The issue mentioned above you also (probably, haven't checked) you may see when you left the screen with ReceyclerView and went back.

----
Continue changing views when the view is reattached.
This is a quick win.
Ideally, I suggest:
1. replace timers with handlers
2. use LifecycleObservers to handle all lifecycle related cases